### PR TITLE
fixed the expression calculating the sigmoid output for both the logistic and log logistic classes

### DIFF
--- a/src/eval_r2/models/logLogistic.py
+++ b/src/eval_r2/models/logLogistic.py
@@ -11,7 +11,7 @@ class LogLogisticModel(BaseKernel):
         self.kernel(b, e, x, kernel_flag="loglinear") # this will create self.log_linear
         # compute the fraction 1/(1 + exp(b*log(x)-e)), since this is common to all model types in this class
         # we're using expit method from scipy to deal with extreme values in the self.log_linear array
-        self.sigmoid = expit(self.log_linear)
+        self.sigmoid = expit(-self.log_linear)
         # now calculate the model predictions
         if model == "L3":
             self.predictions = d * self.sigmoid 

--- a/src/eval_r2/models/logistic.py
+++ b/src/eval_r2/models/logistic.py
@@ -11,7 +11,7 @@ class LogisticModel(BaseKernel):
         self.kernel(b, e, x, kernel_flag="linear") # this will create self.linear
         # compute the fraction 1/(1 + exp(b*log(x)-e)), since this is common to all model types in this class
         # we're using expit method from scipy to deal with extreme values in the self.log_linear array
-        self.sigmoid = expit(self.linear)
+        self.sigmoid = expit(-self.linear)
         # now calculate the model predictions
         if model == "B3":
             self.predictions = d * self.sigmoid 


### PR DESCRIPTION
I had incorrectly assumed that `expit` from `scipy.special` calculated `1/(1+exp(x))` instead of `1/(1+exp(-x))`.
Fixed the argument passed to this function in the `LogisticModel` and `LogLogisticModel` classes.